### PR TITLE
vcpu: Add KVM_KVMCLOCK_CTRL support

### DIFF
--- a/src/ioctls/vcpu.rs
+++ b/src/ioctls/vcpu.rs
@@ -1018,6 +1018,30 @@ impl VcpuFd {
         Ok(reg_value)
     }
 
+    /// Notify the guest about the vCPU being paused.
+    ///
+    /// This signals to the host kernel that the specified guest is being paused by
+    /// userspace.  The host will set a flag in the pvclock structure that is checked
+    /// from the soft lockup watchdog.  The flag is part of the pvclock structure that
+    /// is shared between guest and host, specifically the second bit of the flags
+    /// field of the pvclock_vcpu_time_info structure.  It will be set exclusively by
+    /// the host and read/cleared exclusively by the guest.  The guest operation of
+    /// checking and clearing the flag must an atomic operation so
+    /// load-link/store-conditional, or equivalent must be used.  There are two cases
+    /// where the guest will clear the flag: when the soft lockup watchdog timer resets
+    /// itself or when a soft lockup is detected.  This ioctl can be called any time
+    /// after pausing the vcpu, but before it is resumed.
+    ///
+    pub fn kvmclock_ctrl(&self) -> Result<()> {
+        // Safe because we know that our file is a KVM fd and that the request
+        // is one of the ones defined by kernel.
+        let ret = unsafe { ioctl(self, KVM_KVMCLOCK_CTRL()) };
+        if ret != 0 {
+            return Err(errno::Error::last());
+        }
+        Ok(())
+    }
+
     /// Triggers the running of the current virtual CPU returning an exit reason.
     ///
     /// See documentation for `KVM_RUN`.

--- a/src/kvm_ioctls.rs
+++ b/src/kvm_ioctls.rs
@@ -190,6 +190,9 @@ ioctl_ior_nr!(KVM_GET_XCRS, KVMIO, 0xa6, kvm_xcrs);
 /* Available with KVM_CAP_XCRS */
 #[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
 ioctl_iow_nr!(KVM_SET_XCRS, KVMIO, 0xa7, kvm_xcrs);
+/* Available with KVM_CAP_KVMCLOCK_CTRL */
+#[cfg(any(target_arch = "x86", target_arch = "x86_64"))]
+ioctl_io_nr!(KVM_KVMCLOCK_CTRL, KVMIO, 0xad);
 
 /* Available with KVM_CAP_ENABLE_CAP */
 #[cfg(not(any(target_arch = "arm", target_arch = "aarch64")))]


### PR DESCRIPTION
The KVM_KVMCLOCK_CTRL lets the guest know that it has been paused, which
will prevent from detecting soft lockups due to pausing and resuming
operations.

Signed-off-by: Sebastien Boeuf <sebastien.boeuf@intel.com>